### PR TITLE
Add 'edge' in whichBrowser

### DIFF
--- a/src/unbound/which_browser/index.js
+++ b/src/unbound/which_browser/index.js
@@ -4,6 +4,7 @@ var isFF = require('../is_firefox')
 var isOpera = require('../is_opera')
 var isSafari = require('../is_safari')
 var isIE = require('../is_ie')
+var isEdge = require('../is_edge')
 
 module.exports = function whichBrowser (str) {
   if (isOpera(str)) {
@@ -14,6 +15,8 @@ module.exports = function whichBrowser (str) {
     return 'chrome'
   } else if (isFF(str)) {
     return 'firefox'
+  } else if (isEdge(str)) {
+    return 'edge'
   } else if (isSafari(str)) {
     return 'safari'
   } else if (isIE(str)) {

--- a/src/unbound/which_browser/test.js
+++ b/src/unbound/which_browser/test.js
@@ -51,6 +51,13 @@ test('whichBrowser detects "safari"', (t) => {
   })
 })
 
+test('whichBrowser detects "edge"', (t) => {
+  ;[
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
+    'Mozilla/5.0 (X11; CrOS x86_64 6783.1.0) AppleWebKit/537.36 (KHTML, like Gecko) Edge/12.0'
+  ].forEach((ua) => t.is(whichBrowser(ua), 'edge'))
+})
+
 test("whichBrowser returns undefined if a browser can't be detected", (t) => {
   ;[
     'Mozilla/5.0 (Windows; U; Windows CE 5.2; en-US; rv:1.9.2a1pre) Gecko/20090210 Fennec/0.11'


### PR DESCRIPTION
`whichBrowserVersion` and `whichBrowser` doesn't work well with Edge at the moment.

@kossnocorp I saw #4 but currently `whichBrowserVersion` will detect `safari` and version like `2`